### PR TITLE
feat: use `script` export from loaded script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# mutate-github-repositories-cli
+# Octoherd CLI
 
 > CLI to run a custom script on one or multiple repositories
 
 ## Usage
 
 ```
-$ mutate-github-repositories [script] [repos...]
+$ octoherd [script] [repos...]
 
 Positionals:
   script  Path to your *.js script
@@ -20,24 +20,22 @@ Options:
   --cache    Cache responses for debugging            [boolean] [default: false]
 ```
 
-The `script` must export a default function which takes three parameters:
+The `script` must export a `script` function which takes three parameters:
 
 ```js
-module.exports = exampleScript;
-
-module.exports = async function myScript(octokit, repository, options) {
+module.exports.script = async function myScript(octokit, repository, options) {
   // do something here
 };
 ```
 
 - `octokit` is an instance of [`@octokit/core`](https://github.com/octokit/core.js) with the [`@octokit/plugin-paginate-rest` plugin](https://github.com/octokit/plugin-paginate-rest.js)
 - `repository` is the response data of [`GET /repos/{owner}/{repo}`](https://developer.github.com/v3/repos/#get-a-repository)
-- `options` are all options passed to the CLI which are not used by `mutate-github-repositories`.
+- `options` are all options passed to the CLI which are not used by `octoherd`.
 
 ## Example
 
 ```
-$ npx mutate-github-repositories-cli \
+$ npx @octoherd/cli \
   --token 0123456789012345678901234567890123456789 \
   example.js \
   octokit/*
@@ -53,7 +51,7 @@ See [example.js](example.js) for the syntax of a script.
 
 ## Similar projects
 
-- [NerdWalletOSS/shepherd](https://github.com/NerdWalletOSS/shepherd) - A utility for applying code changes across many repositories. 
+- [NerdWalletOSS/shepherd](https://github.com/NerdWalletOSS/shepherd) - A utility for applying code changes across many repositories.
 - [FormidableLabs/multibot](https://github.com/FormidableLabs/multibot) - A friendly multi-repository robot
 
 ## License

--- a/bin/octoherd.js
+++ b/bin/octoherd.js
@@ -2,7 +2,7 @@
 
 const yargs = require("yargs");
 
-const mutateGithubRepositories = require("..");
+const octoherd = require("..");
 
 var argv = yargs
   .usage("Usage: $0 [options] [script] [repos...]")
@@ -34,4 +34,4 @@ var argv = yargs
   .epilog("copyright 2020").argv;
 
 const { _, $0, ...options } = argv;
-mutateGithubRepositories(options).catch(console.error);
+octoherd(options).catch(console.error);

--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-module.exports = exampleScript;
+module.exports.script = exampleScript;
 
 /**
  * Example script that stars or unstars the passed repository based on the `--unstar` CLI option

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = mutateGithubRepositories;
+module.exports = octoherd;
 
 const { resolve } = require("path");
 
@@ -33,7 +33,7 @@ const Octokit = OctokitCore.plugin(paginateRest, throttling, retry).defaults({
  * @param {string} options.repos Array of repository names in the form of "repo-owner/repo-name". To match all repositories for an owner, pass "repo-owner/*"
  * @param {boolean} options.cache Cache responses for debugging
  */
-async function mutateGithubRepositories(
+async function octoherd(
   options = {
     cache: false,
     repos: [],
@@ -46,16 +46,19 @@ async function mutateGithubRepositories(
   });
 
   let userScript;
+  const path = resolve(process.cwd(), script);
   try {
-    userScript = require(resolve(process.cwd(), script));
+    userScript = require(path).script;
   } catch (error) {
-    throw new Error(
-      `[mutate-github-repositories] ${script} script could not be found`
-    );
+    throw new Error(`[octoherd] ${script} script could not be found`);
+  }
+
+  if (!userScript) {
+    throw new Error(`[octoherd] no "script" exported at ${path}`);
   }
 
   if (repos.length === 0) {
-    throw new Error("[mutate-github-repositories] No repositories provided");
+    throw new Error("[octoherd] No repositories provided");
   }
 
   state = {

--- a/lib/resolve-repositories.js
+++ b/lib/resolve-repositories.js
@@ -6,10 +6,7 @@ async function resolveRepositories(state, repositories) {
   });
 
   if (invalidRepositories.length) {
-    throw new Error(
-      "[mutate-github-repositories] Invalid repositories: %o",
-      invalidRepositories
-    );
+    throw new Error("[octoherd] Invalid repositories: %o", invalidRepositories);
   }
 
   const repositoriesWithStars = repositories.filter((fullName) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mutate-github-repositories-cli",
+  "name": "@octoherd/cli",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "mutate-github-repositories-cli",
-  "version": "1.0.0",
-  "description": "CLI to find github releases in a repository or organization after a specified date",
+  "name": "@octoherd/cli",
+  "publishConfig": {
+    "access": "public"
+  },
+  "version": "0.0.0-development",
+  "description": "CLI to run a custom script on one or multiple repositories",
   "main": "index.js",
   "bin": {
-    "mutate-github-repositories": "bin/mutate-github-repositories.js"
+    "octoherd": "bin/octoherd.js"
   },
   "dependencies": {
     "@octokit/core": "^3.1.2",
@@ -28,21 +31,10 @@
   ],
   "author": "Gregor Martynus (https://twitter.com/gr2m)",
   "license": "MIT",
-  "repository": "https://github.com/gr2m/mutate-github-repositories-cli",
+  "repository": "https://github.com/octoherd/cli",
   "release": {
     "branches": [
-      "+([0-9])?(.{+([0-9]),x}).x",
-      "main",
-      "next",
-      "next-major",
-      {
-        "name": "beta",
-        "prerelease": true
-      },
-      {
-        "name": "alpha",
-        "prerelease": true
-      }
+      "main"
     ]
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: `mutate-github-repositories` is now `octoherd`

BREAKING CHANGE: scripts now have to expert function as `script`. Default export is no longer used