### PR TITLE
fix(run-script-against-repos): add support for capital letters for user&repo

### DIFF
--- a/lib/run-script-against-repositories.js
+++ b/lib/run-script-against-repositories.js
@@ -17,7 +17,7 @@ export async function runScriptAgainstRepositories(state, octoherdRepos = []) {
         const invalid = values.find((value) => {
           if (value.trim() === "*") return;
 
-          if (/^[a-z0-9_.-]+\/[a-z0-9_.*-]+$/.test(value.trim())) {
+          if (/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.*-]+$/.test(value.trim())) {
             return;
           }
 


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
- Improve pattern of repositories to give support for `user`/`org` and `repository` with capital letters

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Repository names and Organization/User names for GitHub are case insensitive.

Fix #41 

## 📊 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing the RegEx pattern here: https://regexr.com/5su0n

Modifying a local script with these changes:

### Before
![image](https://user-images.githubusercontent.com/2574275/118259080-ff930100-b4b0-11eb-8501-fff742daa346.png)

### After
![image](https://user-images.githubusercontent.com/2574275/118259066-f73ac600-b4b0-11eb-9992-17bb6b6b91b8.png)
