### PR TITLE
fix(resolve-repositories): limit to user owned repos

### DIFF
--- a/lib/resolve-repositories.js
+++ b/lib/resolve-repositories.js
@@ -47,7 +47,7 @@ export async function resolveRepositories(state, repositories) {
     for await (const response of state.octokit.paginate.iterator(
       paginateReposRoute,
       {
-        ...(isOrg ? { owner } : {}),
+        ...(isOrg ? { owner } : { affiliation: "owner" }),
         per_page: 100,
       }
     )) {


### PR DESCRIPTION
## 📝 Summary

- Running @octoherd/cli v3.3.2 (@octoherd/octokit v2.3.1, Node.js: v14.16.0, darwin x64)
- Limit to `affiliation: "owner"` for the [`"GET /user/repos"`](https://docs.github.com/en/rest/reference/repos#list-repositories-for-the-authenticated-user) route call.

## ⛱ Motivation and Context

When using `--octoherd-repos "user/*"` with a `repo` scoped Personal Access Token (PAT) `resolveRepositories.js` would find all repositories the user has access to, not only the ones owned by that user under their account.

## 📊 How Has This Been Tested?

Modifying a local script with these changes:

```sh
node cli.js \
  --octoherd-token "0123456789012345678901234567890123456789" \
  --octoherd-repos "stoe/*"
```

### Before

![before](https://user-images.githubusercontent.com/203805/119637535-0a855400-be16-11eb-9290-f2e36c93df19.png)

### After

![after](https://user-images.githubusercontent.com/203805/119636841-5388d880-be15-11eb-8b99-a92ffeaac20a.png)
