### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,12 @@ jobs:
         node:
           - 12
           - 14
-    name: Node ${{ matrix.node }} 
+    name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
