### PR TITLE
ci(action): run tests against LTS version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
         node:
           - 12
           - 14
+          - lts/*
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         node:
           - 12
           - 14
-          - lts/*
+          - 16
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The current LTS version is 16, but rather than hardcoding this version number I went with the version syntax `lts/*` see https://github.com/actions/setup-node#supported-version-syntax