### PR TITLE
chore: improve error message if script could not be loaded

### DIFF
--- a/bin/commands/run.js
+++ b/bin/commands/run.js
@@ -84,9 +84,16 @@ const runCommand = {
         try {
           scriptModule = await import(path);
         } catch (error) {
-          throw new Error(
-            `[octoherd] ${path} does not exist or is not an ES Module`
-          );
+          if (error.code === 'ERR_MODULE_NOT_FOUND') {
+            throw new Error(
+              `[octoherd] ${path} does not exist`
+            );
+          }
+
+          const err = new Error(
+            `[octoherd] ${error}\n    at ${path}`
+          )
+          throw err;
         }
 
         if (!scriptModule.script) {


### PR DESCRIPTION
Today, one of my scripts had a syntax error and it took me several minutes to find out the actual root cause. 

## If script is unwell formed

### Before

```
Error: [octoherd] /Users/stefanb/playground/octoherd-hello.js does not exist or is not an ES Module
    at file:///Users/stefanb/code/octoherd-cli/bin/commands/run.js:87:17
```

### After

```
Error: [octoherd] SyntaxError: Unexpected identifier
    at /Users/stefanb/playground/octoherd-hello.js
    at file:///Users/stefanb/code/octoherd-cli/bin/commands/run.js:93:23
```


## If script can not be found

### Before

```
Error: [octoherd] /Users/stefanb/playground/octoherd-hello.js does not exist or is not an ES Module
    at file:///Users/stefanb/code/octoherd-cli/bin/commands/run.js:87:17
```

### After 
```
Error: [octoherd] /Users/stefanb/playground/octoherd-hello.js does not exist
    at file:///Users/stefanb/code/octoherd-cli/bin/commands/run.js:88:19
```