### PR TITLE
fix: return unique repositories only

### DIFF
--- a/lib/resolve-repositories.js
+++ b/lib/resolve-repositories.js
@@ -79,6 +79,6 @@ export async function resolveRepositories(state, repositories) {
 
   process.stdout.write("\n");
 
-  // return unique array (https://www.samanthaming.com/tidbits/43-3-ways-to-remove-array-duplicates/)
-  return [...new Set(resolvedRepositories)];
+  // return array with unique repositories based by id (https://stackoverflow.com/a/56757215)
+  return resolvedRepositories.filter((repo, index, repoList) => repoList.findIndex(v2 => (v2.id === repo.id)) === index);
 }


### PR DESCRIPTION
I've noticed that Octoherd runs multiple times on the same repository even the code was written in a way to actual prevent this. The current implementation doesn't work, because `resolvedRepositories` is an array of objects like

```js
 {
    id: 243966911,
    node_id: 'MDEwOlJlcG9zaXRvcnkyNDM5NjY5MTE=',
    name: 'OctoLinker',
    full_name: 'OctoLinker/OctoLinker',
   ....
}
```

but the current implementation can deal with primitive types like number , string , boolean only. 


# Before

```
npx @octoherd/script-hello-world -R 'OctoLinker/OctoLinker' -R 'OctoLinker/OctoLinker'

INFO  Running on OctoLinker/OctoLinker ...
INFO  Hello, World! From OctoLinker/OctoLinker
INFO  Running on OctoLinker/OctoLinker ...
INFO  Hello, World! From OctoLinker/OctoLinker
```

# After

```
npx @octoherd/script-hello-world -R 'OctoLinker/OctoLinker' -R 'OctoLinker/OctoLinker'

INFO  Running on OctoLinker/OctoLinker ...
INFO  Hello, World! From OctoLinker/OctoLinker
```
