### PR TITLE
feat: add option to override base url for GHES

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Options:
       --octoherd-debug            Show debug logs                     [boolean] [default: false]
       --octoherd-bypass-confirms  Bypass prompts to confirm mutating requests
                                                                       [boolean] [default: false]
+      --octoherd-base-url         When using with GitHub Enterprise Server, set to the root URL 
+                                  of the API. For example, if your GitHub Enterprise Server's h
+                                  ostname is github.acme-inc.com, then set to https://github.ac
+                                  me-inc.com/api/v3.                                    [string]
       --version                   Show version number                                  [boolean]
 
 Examples:
@@ -35,6 +39,9 @@ Examples:
   octoherd/cli --octoherd-bypass-confirms
   octoherd run -S path/to/script.js -T $TOKEN  -R   Will fetch all repositories except repo-owner/hello-world
   'repo-owner/*' -R '!repo-owner/hello-world
+  octoherd run -S path/to/script.js                 Run octoherd script against GHES
+  --octoherd-base-url 
+  https://github.acme-inc.com/api/v3
 ```
 
 The `script` must export a `script` function which takes three parameters:

--- a/bin/commands/run.js
+++ b/bin/commands/run.js
@@ -46,6 +46,10 @@ const options = {
     type: "boolean",
     default: false,
   },
+  "octoherd-base-url": {
+    description: "When using with GitHub Enterprise Server, set to the root URL of the API. For example, if your GitHub Enterprise Server's hostname is github.acme-inc.com, then set to https://github.acme-inc.com/api/v3.",
+    type: "string",
+  }
 };
 
 /** @type import('yargs').CommandModule */
@@ -69,6 +73,10 @@ const runCommand = {
         [
           "octoherd run -S path/to/script.js -T $TOKEN  -R octoherd/cli --octoherd-bypass-confirms",
           "Avoid any prompts",
+        ],
+        [
+          "octoherd run -S path/to/script.js --octoherd-base-url https://github.acme-inc.com/api/v3",
+          "Run octoherd script against GHES",
         ],
       ])
       .options(options)

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ export async function octoherd(options) {
     octoherdScript,
     octoherdRepos,
     octoherdBypassConfirms,
+    octoherdBaseUrl,
     ...userOptions
   } = options;
 
@@ -74,6 +75,7 @@ export async function octoherd(options) {
   const octokit = new CliOctokit({
     ...authOptions,
     userAgent: ["octoherd-cli", VERSION].join("/"),
+    baseUrl: octoherdBaseUrl,
     octoherd: {
       cache: octoherdCache,
       bypassConfirms: octoherdBypassConfirms,


### PR DESCRIPTION
Adds an option for `--octoherd-base-url` to configure underlying Octokit client for GHES. The URL passed to `--octoherd-base-url` will be passed as `baseUrl` to the underlying Octokit client.


There isn't a current testing pattern in place for the existing options. Open to feedback/ideas on how to add tests for options if desired.