### PR TITLE
fix(README): typo and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export async function script(octokit, repository, options) {
 }
 ```
 
-- `octokit` is an instance of [`@octoherd/octokit`](https://github.com/octoherd/octokit.js)
+- `octokit` is an instance of [`octokit.js`'s Octokit](https://github.com/octokit/octokit.js)
 - `repository` is the response data of [`GET /repos/{owner}/{repo}`](https://developer.github.com/v3/repos/#get-a-repository)
 - `options` are all options passed to the CLI which are not used by `octoherd`.
 


### PR DESCRIPTION
There's not an `octoherd/octokit.js` repo. I believe this is meant to link to `octokit/octokit.js`. Please let me know if you'd like me to change the wording here!