### PR TITLE
feat: initial support for Deno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.env
+.vscode

--- a/bin/commands/run.js
+++ b/bin/commands/run.js
@@ -1,4 +1,4 @@
-import { resolve } from "path";
+import { resolve } from "node:path";
 
 import chalk from "chalk";
 import { VERSION as OctokitVersion } from "@octoherd/octokit";
@@ -8,7 +8,7 @@ import { VERSION } from "../../version.js";
 const VERSIONS = `
 @octoherd/cli:     v${VERSION}
 @octoherd/octokit: v${OctokitVersion}
-Node.js:           ${process.version}, ${process.platform} ${process.arch}`.trim();
+Deno:              ${Deno.version.deno}`.trim();
 
 /** @type { {[key: string]: import("yargs").Options} } */
 const options = {
@@ -47,9 +47,10 @@ const options = {
     default: false,
   },
   "octoherd-base-url": {
-    description: "When using with GitHub Enterprise Server, set to the root URL of the API. For example, if your GitHub Enterprise Server's hostname is github.acme-inc.com, then set to https://github.acme-inc.com/api/v3.",
+    description:
+      "When using with GitHub Enterprise Server, set to the root URL of the API. For example, if your GitHub Enterprise Server's hostname is github.acme-inc.com, then set to https://github.acme-inc.com/api/v3.",
     type: "string",
-  }
+  },
 };
 
 /** @type import('yargs').CommandModule */
@@ -87,20 +88,16 @@ const runCommand = {
         if (typeof script === "function") return script;
 
         let scriptModule;
-        const path = resolve(process.cwd(), script);
+        const path = resolve(Deno.cwd(), script);
 
         try {
           scriptModule = await import(path);
         } catch (error) {
-          if (error.code === 'ERR_MODULE_NOT_FOUND') {
-            throw new Error(
-              `[octoherd] ${path} does not exist`
-            );
+          if (error.code === "ERR_MODULE_NOT_FOUND") {
+            throw new Error(`[octoherd] ${path} does not exist`);
           }
 
-          const err = new Error(
-            `[octoherd] ${error}\n    at ${path}`
-          )
+          const err = new Error(`[octoherd] ${error}\n    at ${path}`);
           throw err;
         }
 
@@ -113,13 +110,11 @@ const runCommand = {
   handler: () => {
     console.log(
       `\n${chalk.bold("Running @octoherd/cli v%s")} ${chalk.gray(
-        "(@octoherd/octokit v%s, Node.js: %s, %s %s)"
+        "(@octoherd/octokit v%s, Deno: %s)"
       )}\n`,
       VERSION,
       OctokitVersion,
-      process.version,
-      process.platform,
-      process.arch
+      Deno.version.deno
     );
   },
 };

--- a/bin/octoherd.js
+++ b/bin/octoherd.js
@@ -1,8 +1,4 @@
-#!/usr/bin/env node
-
-import yargs from "yargs";
-import { hideBin } from "yargs/helpers";
-
+import yargs from "https://deno.land/x/yargs@v17.7.2-deno/deno.ts";
 import chalk from "chalk";
 
 import { octoherd } from "../index.js";
@@ -11,18 +7,18 @@ import runCommand from "./commands/run.js";
 
 const EPILOG = chalk.gray(`Questions? Ideas? Feedback?
 https://github.com/octoherd/octoherd/discussions
-  
+
 Copyright 2020-${new Date().getFullYear()} Octoherd Contributors`);
 
-const argv = await yargs(hideBin(process.argv))
+const { argv } = yargs(Deno.args)
   .command(runCommand)
   .demandCommand()
   .version(VERSION)
-  .epilog(EPILOG).argv;
+  .epilog(EPILOG);
 
 try {
-  await octoherd(argv);
+  octoherd(argv);
 } catch (error) {
-  console.error(error);
-  process.exit(1);
+  console.error({ error });
+  Deno.exit(1);
 }

--- a/bin/run.js
+++ b/bin/run.js
@@ -14,14 +14,14 @@ import runCommand from "./commands/run.js";
  * @param {function} script Octoherd Script function
  */
 export async function run(script) {
-  const argv = await yargs(["run", ...hideBin(process.argv)])
+  const argv = await yargs(["run", ...hideBin(Deno.args)])
     .command(runCommand)
     .default("octoherd-script", () => script).argv;
 
   try {
-    await octoherd(argv);
+    octoherd(argv);
   } catch (error) {
     console.error(error);
-    process.exit(1);
+    Deno.exit(1);
   }
 }

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,4 @@
+import { script } from "./scripts/script.ts";
+import { run } from "./bin/run.js";
+
+run(script);

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "dev": "deno run -A cli.js -T $GITHUB_TOKEN -R 'kurtaking/octoherd-cli'"
+  }
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,659 @@
+{
+  "version": "2",
+  "remote": {
+    "https://deno.land/std@0.200.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
+    "https://deno.land/std@0.200.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.200.0/assert/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.200.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.200.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.200.0/assert/assert_almost_equals.ts": "e15ca1f34d0d5e0afae63b3f5d975cbd18335a132e42b0c747d282f62ad2cd6c",
+    "https://deno.land/std@0.200.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
+    "https://deno.land/std@0.200.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.200.0/assert/assert_exists.ts": "407cb6b9fb23a835cd8d5ad804e2e2edbbbf3870e322d53f79e1c7a512e2efd7",
+    "https://deno.land/std@0.200.0/assert/assert_false.ts": "a9962749f4bf5844e3fa494257f1de73d69e4fe0e82c34d0099287552163a2dc",
+    "https://deno.land/std@0.200.0/assert/assert_instance_of.ts": "09fd297352a5b5bbb16da2b5e1a0d8c6c44da5447772648622dcc7df7af1ddb8",
+    "https://deno.land/std@0.200.0/assert/assert_is_error.ts": "b4eae4e5d182272efc172bf28e2e30b86bb1650cd88aea059e5d2586d4160fb9",
+    "https://deno.land/std@0.200.0/assert/assert_match.ts": "c4083f80600bc190309903c95e397a7c9257ff8b5ae5c7ef91e834704e672e9b",
+    "https://deno.land/std@0.200.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
+    "https://deno.land/std@0.200.0/assert/assert_not_instance_of.ts": "0c14d3dfd9ab7a5276ed8ed0b18c703d79a3d106102077ec437bfe7ed912bd22",
+    "https://deno.land/std@0.200.0/assert/assert_not_match.ts": "3796a5b0c57a1ce6c1c57883dd4286be13a26f715ea662318ab43a8491a13ab0",
+    "https://deno.land/std@0.200.0/assert/assert_not_strict_equals.ts": "ca6c6d645e95fbc873d25320efeb8c4c6089a9a5e09f92d7c1c4b6e935c2a6ad",
+    "https://deno.land/std@0.200.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
+    "https://deno.land/std@0.200.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
+    "https://deno.land/std@0.200.0/assert/assert_strict_equals.ts": "b1f538a7ea5f8348aeca261d4f9ca603127c665e0f2bbfeb91fa272787c87265",
+    "https://deno.land/std@0.200.0/assert/assert_string_includes.ts": "b821d39ebf5cb0200a348863c86d8c4c4b398e02012ce74ad15666fc4b631b0c",
+    "https://deno.land/std@0.200.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
+    "https://deno.land/std@0.200.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.200.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.200.0/assert/fail.ts": "c36353d7ae6e1f7933d45f8ea51e358c8c4b67d7e7502028598fe1fea062e278",
+    "https://deno.land/std@0.200.0/assert/mod.ts": "08d55a652c22c5da0215054b21085cec25a5da47ce4a6f9de7d9ad36df35bdee",
+    "https://deno.land/std@0.200.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
+    "https://deno.land/std@0.200.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
+    "https://deno.land/std@0.200.0/fmt/colors.ts": "a7eecffdf3d1d54db890723b303847b6e0a1ab4b528ba6958b8f2e754cf1b3bc",
+    "https://deno.land/std@0.200.0/fmt/printf.ts": "d3cf1bcc6af4d1ab04747a99f22845abfd0c7ec3cfcc72cfc2b544128a821a12",
+    "https://deno.land/std@0.200.0/path/_basename.ts": "057d420c9049821f983f784fd87fa73ac471901fb628920b67972b0f44319343",
+    "https://deno.land/std@0.200.0/path/_constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
+    "https://deno.land/std@0.200.0/path/_dirname.ts": "355e297236b2218600aee7a5301b937204c62e12da9db4b0b044993d9e658395",
+    "https://deno.land/std@0.200.0/path/_extname.ts": "eaaa5aae1acf1f03254d681bd6a8ce42a9cb5b7ff2213a9d4740e8ab31283664",
+    "https://deno.land/std@0.200.0/path/_format.ts": "4a99270d6810f082e614309164fad75d6f1a483b68eed97c830a506cc589f8b4",
+    "https://deno.land/std@0.200.0/path/_from_file_url.ts": "7e4e5626089785adddb061f1b9f4932d6b21c7df778e7449531a11e32048245c",
+    "https://deno.land/std@0.200.0/path/_interface.ts": "6471159dfbbc357e03882c2266d21ef9afdb1e4aa771b0545e90db58a0ba314b",
+    "https://deno.land/std@0.200.0/path/_is_absolute.ts": "05dac10b5e93c63198b92e3687baa2be178df5321c527dc555266c0f4f51558c",
+    "https://deno.land/std@0.200.0/path/_join.ts": "fd78555bc34d5f188918fc7018dfe8fe2df5bbad94a3b30a433666c03934d77f",
+    "https://deno.land/std@0.200.0/path/_normalize.ts": "a19ec8706b2707f9dd974662a5cd89fad438e62ab1857e08b314a8eb49a34d81",
+    "https://deno.land/std@0.200.0/path/_parse.ts": "0f9b0ff43682dd9964eb1c4398610c4e165d8db9d3ac9d594220217adf480cfa",
+    "https://deno.land/std@0.200.0/path/_relative.ts": "27bdeffb5311a47d85be26d37ad1969979359f7636c5cd9fcf05dcd0d5099dc5",
+    "https://deno.land/std@0.200.0/path/_resolve.ts": "7a3616f1093735ed327e758313b79c3c04ea921808ca5f19ddf240cb68d0adf6",
+    "https://deno.land/std@0.200.0/path/_to_file_url.ts": "739bfda583598790b2e77ce227f2bb618f6ebdb939788cea47555b43970ec58c",
+    "https://deno.land/std@0.200.0/path/_to_namespaced_path.ts": "0d5f4caa2ed98ef7a8786286df6af804b50e38859ae897b5b5b4c8c5930a75c8",
+    "https://deno.land/std@0.200.0/path/_util.ts": "4e191b1bac6b3bf0c31aab42e5ca2e01a86ab5a0d2e08b75acf8585047a86221",
+    "https://deno.land/std@0.200.0/path/basename.ts": "6f08fbb90dbfcf320765b3abb01f995b1723f75e2534acfd5380e202c802a3aa",
+    "https://deno.land/std@0.200.0/path/common.ts": "ee7505ab01fd22de3963b64e46cff31f40de34f9f8de1fff6a1bd2fe79380000",
+    "https://deno.land/std@0.200.0/path/dirname.ts": "098996822a31b4c46e1eb52a19540d3c6f9f54b772fc8a197939eeabc29fca2f",
+    "https://deno.land/std@0.200.0/path/extname.ts": "9b83c62fd16505739541f7a3ab447d8972da39dbf668d47af2f93206c2480893",
+    "https://deno.land/std@0.200.0/path/format.ts": "cb22f95cc7853d590b87708cc9441785e760d711188facff3d225305a8213aca",
+    "https://deno.land/std@0.200.0/path/from_file_url.ts": "a6221cfc928928ec4d9786d767dfac98fa2ab746af0786446c9834a07b98817e",
+    "https://deno.land/std@0.200.0/path/glob.ts": "d479e0a695621c94d3fd7fe7abd4f9499caf32a8de13f25073451c6ef420a4e1",
+    "https://deno.land/std@0.200.0/path/is_absolute.ts": "6b3d36352eb7fa29edb53f9e7b09b1aeb022a3c5465764f6cc5b8c41f9736197",
+    "https://deno.land/std@0.200.0/path/join.ts": "4a2867ff2f3c81ffc9eb3d56dade16db6f8bd3854f269306d23dad4115089c84",
+    "https://deno.land/std@0.200.0/path/mod.ts": "7765507696cb321994cdacfc19ee3ba61e8e3ebf4bd98fa75a276cf5dc18ce2a",
+    "https://deno.land/std@0.200.0/path/normalize.ts": "7d992cd262b2deefa842d93a8ba2ed51f3949ba595b1d07f627ac2cddbc74808",
+    "https://deno.land/std@0.200.0/path/parse.ts": "031fe488b3497fb8312fc1dc3c3d6c2d80707edd9c661e18ee9fd20f95edf322",
+    "https://deno.land/std@0.200.0/path/posix.ts": "0a1c1952d132323a88736d03e92bd236f3ed5f9f079e5823fae07c8d978ee61b",
+    "https://deno.land/std@0.200.0/path/relative.ts": "7db80c5035016174267da16321a742d76e875215c317859a383b12f413c6f5d6",
+    "https://deno.land/std@0.200.0/path/resolve.ts": "103b62207726a27f28177f397008545804ecb20aaf00623af1f622b18cd80b9f",
+    "https://deno.land/std@0.200.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
+    "https://deno.land/std@0.200.0/path/to_file_url.ts": "dd32f7a01bbf3b15b5df46796659984b372973d9b2d7d59bcf0eb990763a0cb5",
+    "https://deno.land/std@0.200.0/path/to_namespaced_path.ts": "4e643ab729bf49ccdc166ad48d2de262ff462938fcf2a44a4425588f4a0bd690",
+    "https://deno.land/std@0.200.0/path/win32.ts": "8b3f80ef7a462511d5e8020ff490edcaa0a0d118f1b1e9da50e2916bdd73f9dd",
+    "https://deno.land/std@0.200.0/testing/asserts.ts": "b4e4b1359393aeff09e853e27901a982c685cb630df30426ed75496961931946",
+    "https://deno.land/x/cliui@v7.0.4-deno/build/lib/index.js": "fb6030c7b12602a4fca4d81de3ddafa301ba84fd9df73c53de6f3bdda7b482d5",
+    "https://deno.land/x/cliui@v7.0.4-deno/build/lib/string-utils.js": "b3eb9d2e054a43a3064af17332fb1839a7dadb205c5371af4789616afb1a117f",
+    "https://deno.land/x/cliui@v7.0.4-deno/deno.ts": "d07bc3338661f8011e3a5fd215061d17a52107a5383c29f40ce0c1ecb8bb8cc3",
+    "https://deno.land/x/escalade@v3.0.3/sync.ts": "493bc66563292c5c10c4a75a467a5933f24dad67d74b0f5a87e7b988fe97c104",
+    "https://deno.land/x/y18n@v5.0.0-deno/build/lib/index.js": "92c4624714aa508d33c6d21c0b0ffa072369a8b306e5f8c7727662f570bbd026",
+    "https://deno.land/x/y18n@v5.0.0-deno/deno.ts": "80997f0709a0b43d29931e2b33946f2bbc32b13fd82f80a5409628455427e28d",
+    "https://deno.land/x/y18n@v5.0.0-deno/lib/platform-shims/deno.ts": "8fa2c96ac03734966260cfd2c5bc240e41725c913e5b64a0297aede09f52b39d",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/argsert.js": "eb085555452eac3ff300935994a42f35d16e04cf698cb775cb5ad4f5653c0627",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/command.js": "6249ffd299e16a1e531ccff13a23aed7b7eef37e20b6e6ab7f254413aece6ca6",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/completion-templates.js": "d9bbed244af4394b786f8abce9efbbdc3777a73458ebd7b6bf23b2495ac11027",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/completion.js": "62e41220b5baa7c082f72638c7eab23a69fff46a78011f2c448e2a2f1fcfd05a",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/middleware.js": "6ab9c953a83264739aa50d7fa6b1ab693500336dfd593b9958865e12beb8bdeb",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/parse-command.js": "327242c0afae207b7aefa13133439e3b321d7db4229febc5b7bd5285770ac7f7",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/typings/common-types.js": "9618b81a86acb88a61fd9988e9bc3ec21c5250d94fc2231ba7d898e71500789d",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/usage.js": "31faaa7aa61e5a57a2cac5a269b773aa8b1fcab2db7cac2f8252396f3ccc2f5e",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/utils/apply-extends.js": "64640dce92669705abead3bdbe2c46c8318c8623843a55e4726fb3c55ff9dd1d",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/utils/is-promise.js": "be45baa3090c5106dd4e442cceef6b357a268783a2ee28ec10fe131a8cd8db72",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/utils/levenshtein.js": "d8638efc3376b5f794b1c8df6ef4f3d484b29d919127c7fdc242400e3cfded91",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/utils/maybe-async-result.js": "31cf4026279e14c87d16faa14ac758f35c8cc5795d29393c5ce07120f5a3caf6",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/utils/obj-filter.js": "5523fb2288d1e86ed48c460e176770b49587554df4ae2405b468c093786b040b",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/utils/set-blocking.js": "6fa8ffc3299f456e42902736bae35fbc1f2dc96b3905a02ba9629f5bd9f80af1",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/utils/which-module.js": "9267633b2c9f8990b2c699101b641e59ae59932e0dee5270613c0508bfa13c5d",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/validation.js": "af040834cb9201d4238bbeb8f673eb2ebaff9611857270524a7c86dfcf2ca51b",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/yargs-factory.js": "05326932b431801d7459d5b14b21f73f13ebd74a8a74e9b7b8cec5f99ba14819",
+    "https://deno.land/x/yargs@v17.7.2-deno/build/lib/yerror.js": "9729aaa8bce1a0d00c57f470efb2ad76ad2988661bb48f3769e496a3435b4462",
+    "https://deno.land/x/yargs@v17.7.2-deno/deno-types.ts": "62f5c61899c6da491890c8c84fd9580cfbfa2a83f5a70f6dc74727bbfb148623",
+    "https://deno.land/x/yargs@v17.7.2-deno/deno.ts": "f3df0bfd08ba367ec36dc59ef6cab1a391ace49ad44387ec5fe5d76289af08af",
+    "https://deno.land/x/yargs@v17.7.2-deno/lib/platform-shims/deno.ts": "1d3d490a7f3c6f971a44dd92e12a042f988f1b6496df3a9c43ccc69563032dff",
+    "https://deno.land/x/yargs_parser@v20.2.4-deno/build/lib/string-utils.js": "12fc056b23703bc370aae5b179dc5abee53fca277abc30eaf76f78d2546d6413",
+    "https://deno.land/x/yargs_parser@v20.2.4-deno/build/lib/tokenize-arg-string.js": "7e0875b11795b8e217386e45f14b24a6e501ebbc62e15aa469aa8829d4d0ee61",
+    "https://deno.land/x/yargs_parser@v20.2.4-deno/build/lib/yargs-parser.js": "453200a7dfbb002e605d8009b7dad30f2b1d93665e046ab89c073a4fe63dfd48",
+    "https://deno.land/x/yargs_parser@v20.2.4-deno/deno.ts": "ad53c0c82c3982c4fc5be9472384b259e0a32ce1f7ae0f68de7b2445df5642fc"
+  },
+  "npm": {
+    "specifiers": {
+      "@octoherd/octokit@^4.0.0": "@octoherd/octokit@4.0.0_@octokit+core@5.0.0",
+      "@octokit/auth-oauth-device@^6.0.0": "@octokit/auth-oauth-device@6.0.0",
+      "@octokit/openapi-types@^18.0.0": "@octokit/openapi-types@18.0.0",
+      "@octokit/openapi@^12.0.0": "@octokit/openapi@12.0.0",
+      "chalk@^5.0.0": "chalk@5.3.0",
+      "clipboardy@^3.0.0": "clipboardy@3.0.0",
+      "enquirer@^2.3.6": "enquirer@2.4.1",
+      "jsonfile@^6.0.1": "jsonfile@6.1.0",
+      "mkdirp@^3.0.0": "mkdirp@3.0.1",
+      "prettier@^3.0.0": "prettier@3.0.2",
+      "simple-mock@^0.8.0": "simple-mock@0.8.0",
+      "tempy@^3.0.0": "tempy@3.1.0",
+      "uvu@^0.5.1": "uvu@0.5.6",
+      "yargs@^17.0.0-candidate.10": "yargs@17.7.2"
+    },
+    "packages": {
+      "@octoherd/octokit@4.0.0_@octokit+core@5.0.0": {
+        "integrity": "sha512-MHSg8nGyloR+MIxTIDknkQIzFc5oT98Apf5xChQKKUct+xQhZH4GyHBiR0OPrKiCFlfnaCUgRGZ4o64cfiSUGw==",
+        "dependencies": {
+          "@octokit/core": "@octokit/core@5.0.0",
+          "@octokit/plugin-paginate-rest": "@octokit/plugin-paginate-rest@8.0.0_@octokit+core@5.0.0",
+          "@octokit/plugin-retry": "@octokit/plugin-retry@6.0.0_@octokit+core@5.0.0",
+          "@octokit/plugin-throttling": "@octokit/plugin-throttling@7.0.0_@octokit+core@5.0.0",
+          "quick-format-unescaped": "quick-format-unescaped@4.0.4",
+          "semantic-release-plugin-update-version-in-files": "semantic-release-plugin-update-version-in-files@1.1.0"
+        }
+      },
+      "@octokit/auth-oauth-device@6.0.0": {
+        "integrity": "sha512-Zgf/LKhwWk54rJaTGYVYtbKgUty+ouil6VQeRd+pCw7Gd0ECoSWaZuHK6uDGC/HtnWHjpSWFhzxPauDoHcNRtg==",
+        "dependencies": {
+          "@octokit/oauth-methods": "@octokit/oauth-methods@4.0.0",
+          "@octokit/request": "@octokit/request@8.1.1",
+          "@octokit/types": "@octokit/types@11.1.0",
+          "universal-user-agent": "universal-user-agent@6.0.0"
+        }
+      },
+      "@octokit/auth-token@4.0.0": {
+        "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+        "dependencies": {}
+      },
+      "@octokit/core@5.0.0": {
+        "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
+        "dependencies": {
+          "@octokit/auth-token": "@octokit/auth-token@4.0.0",
+          "@octokit/graphql": "@octokit/graphql@7.0.1",
+          "@octokit/request": "@octokit/request@8.1.1",
+          "@octokit/request-error": "@octokit/request-error@5.0.0",
+          "@octokit/types": "@octokit/types@11.1.0",
+          "before-after-hook": "before-after-hook@2.2.3",
+          "universal-user-agent": "universal-user-agent@6.0.0"
+        }
+      },
+      "@octokit/endpoint@9.0.0": {
+        "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+        "dependencies": {
+          "@octokit/types": "@octokit/types@11.1.0",
+          "is-plain-object": "is-plain-object@5.0.0",
+          "universal-user-agent": "universal-user-agent@6.0.0"
+        }
+      },
+      "@octokit/graphql@7.0.1": {
+        "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
+        "dependencies": {
+          "@octokit/request": "@octokit/request@8.1.1",
+          "@octokit/types": "@octokit/types@11.1.0",
+          "universal-user-agent": "universal-user-agent@6.0.0"
+        }
+      },
+      "@octokit/oauth-authorization-url@6.0.2": {
+        "integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==",
+        "dependencies": {}
+      },
+      "@octokit/oauth-methods@4.0.0": {
+        "integrity": "sha512-dqy7BZLfLbi3/8X8xPKUKZclMEK9vN3fK5WF3ortRvtplQTszFvdAGbTo71gGLO+4ZxspNiLjnqdd64Chklf7w==",
+        "dependencies": {
+          "@octokit/oauth-authorization-url": "@octokit/oauth-authorization-url@6.0.2",
+          "@octokit/request": "@octokit/request@8.1.1",
+          "@octokit/request-error": "@octokit/request-error@5.0.0",
+          "@octokit/types": "@octokit/types@11.1.0",
+          "btoa-lite": "btoa-lite@1.0.0"
+        }
+      },
+      "@octokit/openapi-types@18.0.0": {
+        "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+        "dependencies": {}
+      },
+      "@octokit/openapi@12.0.0": {
+        "integrity": "sha512-RqrGD4NlVpwqLhzoKYqF1D0gRZQajsNBQSkxn3emSiKe7lHGTWqH2mTGz670SuUhSVE5FiWJJbGmoXLOpIAong==",
+        "dependencies": {}
+      },
+      "@octokit/plugin-paginate-rest@8.0.0_@octokit+core@5.0.0": {
+        "integrity": "sha512-2xZ+baZWUg+qudVXnnvXz7qfrTmDeYPCzangBVq/1gXxii/OiS//4shJp9dnCCvj1x+JAm9ji1Egwm1BA47lPQ==",
+        "dependencies": {
+          "@octokit/core": "@octokit/core@5.0.0",
+          "@octokit/types": "@octokit/types@11.1.0"
+        }
+      },
+      "@octokit/plugin-retry@6.0.0_@octokit+core@5.0.0": {
+        "integrity": "sha512-a1/A4A+PB1QoAHQfLJxGHhLfSAT03bR1jJz3GgQJZvty2ozawFWs93MiBQXO7SL2YbO7CIq0Goj4qLOBj8JeMQ==",
+        "dependencies": {
+          "@octokit/core": "@octokit/core@5.0.0",
+          "@octokit/request-error": "@octokit/request-error@5.0.0",
+          "@octokit/types": "@octokit/types@11.1.0",
+          "bottleneck": "bottleneck@2.19.5"
+        }
+      },
+      "@octokit/plugin-throttling@7.0.0_@octokit+core@5.0.0": {
+        "integrity": "sha512-KL2k/d0uANc8XqP5S64YcNFCudR3F5AaKO39XWdUtlJIjT9Ni79ekWJ6Kj5xvAw87udkOMEPcVf9xEge2+ahew==",
+        "dependencies": {
+          "@octokit/core": "@octokit/core@5.0.0",
+          "@octokit/types": "@octokit/types@11.1.0",
+          "bottleneck": "bottleneck@2.19.5"
+        }
+      },
+      "@octokit/request-error@5.0.0": {
+        "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
+        "dependencies": {
+          "@octokit/types": "@octokit/types@11.1.0",
+          "deprecation": "deprecation@2.3.1",
+          "once": "once@1.4.0"
+        }
+      },
+      "@octokit/request@8.1.1": {
+        "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
+        "dependencies": {
+          "@octokit/endpoint": "@octokit/endpoint@9.0.0",
+          "@octokit/request-error": "@octokit/request-error@5.0.0",
+          "@octokit/types": "@octokit/types@11.1.0",
+          "is-plain-object": "is-plain-object@5.0.0",
+          "universal-user-agent": "universal-user-agent@6.0.0"
+        }
+      },
+      "@octokit/types@11.1.0": {
+        "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+        "dependencies": {
+          "@octokit/openapi-types": "@octokit/openapi-types@18.0.0"
+        }
+      },
+      "ansi-colors@4.1.3": {
+        "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+        "dependencies": {}
+      },
+      "ansi-regex@5.0.1": {
+        "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+        "dependencies": {}
+      },
+      "ansi-styles@4.3.0": {
+        "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+        "dependencies": {
+          "color-convert": "color-convert@2.0.1"
+        }
+      },
+      "arch@2.2.0": {
+        "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+        "dependencies": {}
+      },
+      "balanced-match@1.0.2": {
+        "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+        "dependencies": {}
+      },
+      "before-after-hook@2.2.3": {
+        "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+        "dependencies": {}
+      },
+      "bottleneck@2.19.5": {
+        "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+        "dependencies": {}
+      },
+      "brace-expansion@1.1.11": {
+        "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+        "dependencies": {
+          "balanced-match": "balanced-match@1.0.2",
+          "concat-map": "concat-map@0.0.1"
+        }
+      },
+      "btoa-lite@1.0.0": {
+        "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+        "dependencies": {}
+      },
+      "chalk@5.3.0": {
+        "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+        "dependencies": {}
+      },
+      "clipboardy@3.0.0": {
+        "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+        "dependencies": {
+          "arch": "arch@2.2.0",
+          "execa": "execa@5.1.1",
+          "is-wsl": "is-wsl@2.2.0"
+        }
+      },
+      "cliui@8.0.1": {
+        "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+        "dependencies": {
+          "string-width": "string-width@4.2.3",
+          "strip-ansi": "strip-ansi@6.0.1",
+          "wrap-ansi": "wrap-ansi@7.0.0"
+        }
+      },
+      "color-convert@2.0.1": {
+        "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+        "dependencies": {
+          "color-name": "color-name@1.1.4"
+        }
+      },
+      "color-name@1.1.4": {
+        "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+        "dependencies": {}
+      },
+      "concat-map@0.0.1": {
+        "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+        "dependencies": {}
+      },
+      "cross-spawn@7.0.3": {
+        "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+        "dependencies": {
+          "path-key": "path-key@3.1.1",
+          "shebang-command": "shebang-command@2.0.0",
+          "which": "which@2.0.2"
+        }
+      },
+      "crypto-random-string@4.0.0": {
+        "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+        "dependencies": {
+          "type-fest": "type-fest@1.4.0"
+        }
+      },
+      "debug@4.3.4": {
+        "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+        "dependencies": {
+          "ms": "ms@2.1.2"
+        }
+      },
+      "deprecation@2.3.1": {
+        "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+        "dependencies": {}
+      },
+      "dequal@2.0.3": {
+        "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+        "dependencies": {}
+      },
+      "diff@5.1.0": {
+        "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+        "dependencies": {}
+      },
+      "emoji-regex@8.0.0": {
+        "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+        "dependencies": {}
+      },
+      "enquirer@2.4.1": {
+        "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+        "dependencies": {
+          "ansi-colors": "ansi-colors@4.1.3",
+          "strip-ansi": "strip-ansi@6.0.1"
+        }
+      },
+      "escalade@3.1.1": {
+        "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+        "dependencies": {}
+      },
+      "execa@5.1.1": {
+        "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+        "dependencies": {
+          "cross-spawn": "cross-spawn@7.0.3",
+          "get-stream": "get-stream@6.0.1",
+          "human-signals": "human-signals@2.1.0",
+          "is-stream": "is-stream@2.0.1",
+          "merge-stream": "merge-stream@2.0.0",
+          "npm-run-path": "npm-run-path@4.0.1",
+          "onetime": "onetime@5.1.2",
+          "signal-exit": "signal-exit@3.0.7",
+          "strip-final-newline": "strip-final-newline@2.0.0"
+        }
+      },
+      "fs.realpath@1.0.0": {
+        "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+        "dependencies": {}
+      },
+      "get-caller-file@2.0.5": {
+        "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+        "dependencies": {}
+      },
+      "get-stream@6.0.1": {
+        "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+        "dependencies": {}
+      },
+      "glob@7.2.3": {
+        "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+        "dependencies": {
+          "fs.realpath": "fs.realpath@1.0.0",
+          "inflight": "inflight@1.0.6",
+          "inherits": "inherits@2.0.4",
+          "minimatch": "minimatch@3.1.2",
+          "once": "once@1.4.0",
+          "path-is-absolute": "path-is-absolute@1.0.1"
+        }
+      },
+      "graceful-fs@4.2.11": {
+        "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+        "dependencies": {}
+      },
+      "human-signals@2.1.0": {
+        "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+        "dependencies": {}
+      },
+      "inflight@1.0.6": {
+        "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+        "dependencies": {
+          "once": "once@1.4.0",
+          "wrappy": "wrappy@1.0.2"
+        }
+      },
+      "inherits@2.0.4": {
+        "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+        "dependencies": {}
+      },
+      "is-docker@2.2.1": {
+        "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+        "dependencies": {}
+      },
+      "is-fullwidth-code-point@3.0.0": {
+        "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+        "dependencies": {}
+      },
+      "is-plain-object@5.0.0": {
+        "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+        "dependencies": {}
+      },
+      "is-stream@2.0.1": {
+        "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+        "dependencies": {}
+      },
+      "is-stream@3.0.0": {
+        "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+        "dependencies": {}
+      },
+      "is-wsl@2.2.0": {
+        "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+        "dependencies": {
+          "is-docker": "is-docker@2.2.1"
+        }
+      },
+      "isexe@2.0.0": {
+        "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+        "dependencies": {}
+      },
+      "jsonfile@6.1.0": {
+        "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+        "dependencies": {
+          "graceful-fs": "graceful-fs@4.2.11",
+          "universalify": "universalify@2.0.0"
+        }
+      },
+      "kleur@4.1.5": {
+        "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+        "dependencies": {}
+      },
+      "merge-stream@2.0.0": {
+        "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+        "dependencies": {}
+      },
+      "mimic-fn@2.1.0": {
+        "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+        "dependencies": {}
+      },
+      "minimatch@3.1.2": {
+        "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+        "dependencies": {
+          "brace-expansion": "brace-expansion@1.1.11"
+        }
+      },
+      "mkdirp@3.0.1": {
+        "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+        "dependencies": {}
+      },
+      "mri@1.2.0": {
+        "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+        "dependencies": {}
+      },
+      "ms@2.1.2": {
+        "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+        "dependencies": {}
+      },
+      "npm-run-path@4.0.1": {
+        "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+        "dependencies": {
+          "path-key": "path-key@3.1.1"
+        }
+      },
+      "once@1.4.0": {
+        "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+        "dependencies": {
+          "wrappy": "wrappy@1.0.2"
+        }
+      },
+      "onetime@5.1.2": {
+        "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+        "dependencies": {
+          "mimic-fn": "mimic-fn@2.1.0"
+        }
+      },
+      "path-is-absolute@1.0.1": {
+        "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+        "dependencies": {}
+      },
+      "path-key@3.1.1": {
+        "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+        "dependencies": {}
+      },
+      "prettier@3.0.2": {
+        "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+        "dependencies": {}
+      },
+      "quick-format-unescaped@4.0.4": {
+        "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+        "dependencies": {}
+      },
+      "require-directory@2.1.1": {
+        "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+        "dependencies": {}
+      },
+      "sade@1.8.1": {
+        "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+        "dependencies": {
+          "mri": "mri@1.2.0"
+        }
+      },
+      "semantic-release-plugin-update-version-in-files@1.1.0": {
+        "integrity": "sha512-OWBrved3Rr0w3YP4iID81MhG9qhGrG+XtxdO9VMhKJ9qte3yBdMz5cSxDiPE/uhnGJQF00fqQetY3yhHFGabWw==",
+        "dependencies": {
+          "debug": "debug@4.3.4",
+          "glob": "glob@7.2.3"
+        }
+      },
+      "shebang-command@2.0.0": {
+        "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+        "dependencies": {
+          "shebang-regex": "shebang-regex@3.0.0"
+        }
+      },
+      "shebang-regex@3.0.0": {
+        "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+        "dependencies": {}
+      },
+      "signal-exit@3.0.7": {
+        "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+        "dependencies": {}
+      },
+      "simple-mock@0.8.0": {
+        "integrity": "sha512-rakKnocwPH9KPjOsmtMwJwKDmZIYyDeCz0bQYAdeB9h27SMpS5BS+0hDSzhAlvmzA3o7I9ck2NgqjcHpjIcwmA==",
+        "dependencies": {}
+      },
+      "string-width@4.2.3": {
+        "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+        "dependencies": {
+          "emoji-regex": "emoji-regex@8.0.0",
+          "is-fullwidth-code-point": "is-fullwidth-code-point@3.0.0",
+          "strip-ansi": "strip-ansi@6.0.1"
+        }
+      },
+      "strip-ansi@6.0.1": {
+        "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+        "dependencies": {
+          "ansi-regex": "ansi-regex@5.0.1"
+        }
+      },
+      "strip-final-newline@2.0.0": {
+        "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+        "dependencies": {}
+      },
+      "temp-dir@3.0.0": {
+        "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+        "dependencies": {}
+      },
+      "tempy@3.1.0": {
+        "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+        "dependencies": {
+          "is-stream": "is-stream@3.0.0",
+          "temp-dir": "temp-dir@3.0.0",
+          "type-fest": "type-fest@2.19.0",
+          "unique-string": "unique-string@3.0.0"
+        }
+      },
+      "type-fest@1.4.0": {
+        "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+        "dependencies": {}
+      },
+      "type-fest@2.19.0": {
+        "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+        "dependencies": {}
+      },
+      "unique-string@3.0.0": {
+        "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+        "dependencies": {
+          "crypto-random-string": "crypto-random-string@4.0.0"
+        }
+      },
+      "universal-user-agent@6.0.0": {
+        "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+        "dependencies": {}
+      },
+      "universalify@2.0.0": {
+        "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+        "dependencies": {}
+      },
+      "uvu@0.5.6": {
+        "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+        "dependencies": {
+          "dequal": "dequal@2.0.3",
+          "diff": "diff@5.1.0",
+          "kleur": "kleur@4.1.5",
+          "sade": "sade@1.8.1"
+        }
+      },
+      "which@2.0.2": {
+        "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+        "dependencies": {
+          "isexe": "isexe@2.0.0"
+        }
+      },
+      "wrap-ansi@7.0.0": {
+        "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+        "dependencies": {
+          "ansi-styles": "ansi-styles@4.3.0",
+          "string-width": "string-width@4.2.3",
+          "strip-ansi": "strip-ansi@6.0.1"
+        }
+      },
+      "wrappy@1.0.2": {
+        "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+        "dependencies": {}
+      },
+      "y18n@5.0.8": {
+        "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+        "dependencies": {}
+      },
+      "yargs-parser@21.1.1": {
+        "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+        "dependencies": {}
+      },
+      "yargs@17.7.2": {
+        "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+        "dependencies": {
+          "cliui": "cliui@8.0.1",
+          "escalade": "escalade@3.1.1",
+          "get-caller-file": "get-caller-file@2.0.5",
+          "require-directory": "require-directory@2.1.1",
+          "string-width": "string-width@4.2.3",
+          "y18n": "y18n@5.0.8",
+          "yargs-parser": "yargs-parser@21.1.1"
+        }
+      }
+    }
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-import { octoherd } from "./index.js";
 import { components } from "@octokit/openapi-types";
 
 export { Octokit } from "@octoherd/octokit";

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { appendFileSync } from "fs";
+import { appendFileSync } from "node:fs";
 
 import { Octokit } from "@octoherd/octokit";
 import { createOAuthDeviceAuth } from "@octokit/auth-oauth-device";

--- a/lib/octokit-plugin-cache.js
+++ b/lib/octokit-plugin-cache.js
@@ -1,5 +1,5 @@
-import { URL } from "url";
-import { dirname, join } from "path";
+import { URL } from "node:url";
+import { dirname, join } from "node:path";
 
 import { mkdirp } from "mkdirp";
 import jsonfile from "jsonfile";

--- a/lib/octokit-plugin-request-confirm.js
+++ b/lib/octokit-plugin-request-confirm.js
@@ -1,4 +1,3 @@
-// import Confirm from "prompt-confirm";
 import enquirer from "enquirer";
 import chalk from "chalk";
 

--- a/lib/octokit-plugin-request-log.js
+++ b/lib/octokit-plugin-request-log.js
@@ -1,5 +1,5 @@
 export function requestLog(octokit) {
-  octokit.hook.wrap("request", async (request, options) => {
+  octokit.hook.wrap("request", (request, options) => {
     const start = Date.now();
     const requestOptions = octokit.request.endpoint.parse(options);
     const path = requestOptions.url.replace(options.baseUrl, "");

--- a/lib/resolve-repositories.js
+++ b/lib/resolve-repositories.js
@@ -34,7 +34,7 @@ export async function resolveRepositories(state, repositories) {
 
       state.octokit.log.warn(`Repository ${owner}/${repo} could not be found`);
     }
-    // Deno.stdout.W(".");
+    Deno.stdout.write(new TextEncoder().encode("."));
   }
 
   for (const name of repositoriesWithStars) {
@@ -70,7 +70,7 @@ export async function resolveRepositories(state, repositories) {
       }
 
       resolvedRepositories.push(...selectedRepositories);
-      // Deno.stdout.write(".");
+      Deno.stdout.write(new TextEncoder().encode("."));
     }
   }
 
@@ -82,11 +82,11 @@ export async function resolveRepositories(state, repositories) {
       }
     )) {
       resolvedRepositories.push(...response.data);
-      // Deno.stdout.write(".");
+      Deno.stdout.write(new TextEncoder().encode("."));
     }
   }
 
-  // Deno.stdout.write("\n");
+  Deno.stdout.write(new TextEncoder().encode("\n"));
 
   function includesRepository(list, repo) {
     return list.some((x) => x.toLowerCase() === repo.full_name.toLowerCase());

--- a/lib/resolve-repositories.js
+++ b/lib/resolve-repositories.js
@@ -1,19 +1,21 @@
 export async function resolveRepositories(state, repositories) {
   const ignoreRepositories = repositories.reduce((memo, fullName) => {
-    if (fullName.startsWith('!')) {
-      memo.push(fullName.slice(1))
+    if (fullName.startsWith("!")) {
+      memo.push(fullName.slice(1));
     }
     return memo;
   }, []);
 
   const repositoriesWithStars = repositories.filter((fullName) => {
-    return /^[a-z0-9_.-]+\/(\*|[a-z0-9_.-]+\*|\*[a-z0-9_.-]+|[a-z0-9_.-]+\*[a-z0-9_.-]+)$/i.test(
-      fullName
-    ) && !fullName.startsWith('!');
+    return (
+      /^[a-z0-9_.-]+\/(\*|[a-z0-9_.-]+\*|\*[a-z0-9_.-]+|[a-z0-9_.-]+\*[a-z0-9_.-]+)$/i.test(
+        fullName
+      ) && !fullName.startsWith("!")
+    );
   });
 
   const repositoriesWithoutStars = repositories.filter((fullName) => {
-    return !/\*/i.test(fullName) && !fullName.startsWith('!');
+    return !/\*/i.test(fullName) && !fullName.startsWith("!");
   });
   const allRepositories = !!repositories.find((name) => name === "*");
 
@@ -32,7 +34,7 @@ export async function resolveRepositories(state, repositories) {
 
       state.octokit.log.warn(`Repository ${owner}/${repo} could not be found`);
     }
-    process.stdout.write(".");
+    // Deno.stdout.W(".");
   }
 
   for (const name of repositoriesWithStars) {
@@ -68,7 +70,7 @@ export async function resolveRepositories(state, repositories) {
       }
 
       resolvedRepositories.push(...selectedRepositories);
-      process.stdout.write(".");
+      // Deno.stdout.write(".");
     }
   }
 
@@ -80,18 +82,21 @@ export async function resolveRepositories(state, repositories) {
       }
     )) {
       resolvedRepositories.push(...response.data);
-      process.stdout.write(".");
+      // Deno.stdout.write(".");
     }
   }
 
-  process.stdout.write("\n");
+  // Deno.stdout.write("\n");
 
   function includesRepository(list, repo) {
-    return list.some((x) => x.toLowerCase() === repo.full_name.toLowerCase())
+    return list.some((x) => x.toLowerCase() === repo.full_name.toLowerCase());
   }
 
   // return array with unique repositories based by id (https://stackoverflow.com/a/56757215)
   return resolvedRepositories
-    .filter((repo, index, repoList) => repoList.findIndex(v2 => (v2.id === repo.id)) === index)
-    .filter(repo => !includesRepository(ignoreRepositories, repo))
+    .filter(
+      (repo, index, repoList) =>
+        repoList.findIndex((v2) => v2.id === repo.id) === index
+    )
+    .filter((repo) => !includesRepository(ignoreRepositories, repo));
 }

--- a/lib/run-script-against-repositories.js
+++ b/lib/run-script-against-repositories.js
@@ -69,7 +69,7 @@ export async function runScriptAgainstRepositories(state, octoherdRepos = []) {
     }
   } catch (error) {
     state.octokit.log.error(error);
-    process.exitCode = 1;
+    Deno.exitCode = 1;
   }
 
   await runScriptAgainstRepositories(state);

--- a/scripts/generate-endpoints.js
+++ b/scripts/generate-endpoints.js
@@ -1,5 +1,4 @@
-import { writeFile } from "fs/promises";
-
+import { writeFile } from "node:fs/promises";
 import prettier from "prettier";
 import OpenAPI from "@octokit/openapi";
 

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1,0 +1,32 @@
+/*
+source code from:
+https://github.com/octoherd/script-rename-master-branch-to-main/blob/main/script.js
+*/
+
+export async function script(octokit, repository) {
+  if (repository.default_branch !== "master") {
+    octokit.log.info(
+      `Default branch is not "master" but "${repository.default_branch}", ignoring`
+    );
+    return;
+  }
+
+  if (!repository.permissions.admin) {
+    octokit.log.warn(`You don't have admin permission, ignoring`);
+    return;
+  }
+
+  if (repository.archived) {
+    octokit.log.info(`Repository is archived, ignoring`);
+    return;
+  }
+
+  await octokit.request("POST /repos/{owner}/{repo}/branches/{branch}/rename", {
+    owner: repository.owner.login,
+    repo: repository.name,
+    branch: "master",
+    new_name: "main",
+  });
+
+  octokit.log.info(`Default branch renamed to "main"`);
+}

--- a/scripts/script.ts
+++ b/scripts/script.ts
@@ -1,0 +1,32 @@
+/*
+source code from:
+https://github.com/octoherd/script-rename-master-branch-to-main/blob/main/script.js
+*/
+
+export async function script(octokit, repository) {
+  if (repository.default_branch !== "master") {
+    octokit.log.info(
+      `Default branch is not "master" but "${repository.default_branch}", ignoring`
+    );
+    return;
+  }
+
+  if (!repository.permissions.admin) {
+    octokit.log.warn(`You don't have admin permission, ignoring`);
+    return;
+  }
+
+  if (repository.archived) {
+    octokit.log.info(`Repository is archived, ignoring`);
+    return;
+  }
+
+  await octokit.request("POST /repos/{owner}/{repo}/branches/{branch}/rename", {
+    owner: repository.owner.login,
+    repo: repository.name,
+    branch: "master",
+    new_name: "main",
+  });
+
+  octokit.log.info(`Default branch renamed to "main"`);
+}

--- a/tests/resolve-repositories.test.js
+++ b/tests/resolve-repositories.test.js
@@ -186,7 +186,7 @@ withOrg(
     const org = "octoherd";
     const repo = "script-*";
     const octokit = new Octokit({
-      auth: process.env.GITHUB_TOKEN,
+      auth: Deno.env.GITHUB_TOKEN,
     });
 
     const repositories = [`${org}/${repo}`];
@@ -238,7 +238,7 @@ withOrg(
     const org = "octoherd";
     const repo = "*-test";
     const octokit = new Octokit({
-      auth: process.env.GITHUB_TOKEN,
+      auth: Deno.env.GITHUB_TOKEN,
     });
 
     const repositories = [`${org}/${repo}`];
@@ -249,7 +249,10 @@ withOrg(
       { id: 3, name: "three-test" },
     ];
 
-    const nonTestRepos = [{ id: 4, name: "foo" }, { id: 5, name: "bar" }];
+    const nonTestRepos = [
+      { id: 4, name: "foo" },
+      { id: 5, name: "bar" },
+    ];
 
     simple.mock(octokit, "request").resolveWith(undefined);
 
@@ -276,7 +279,7 @@ withOrg(
     const org = "octoherd";
     const repo = "middle-*-test";
     const octokit = new Octokit({
-      auth: process.env.GITHUB_TOKEN,
+      auth: Deno.env.GITHUB_TOKEN,
     });
 
     const repositories = [`${org}/${repo}`];
@@ -287,7 +290,10 @@ withOrg(
       { id: 3, name: "middle-three-test" },
     ];
 
-    const nonTestRepos = [{ id: 4, name: "foo" }, { id: 5, name: "bar" }];
+    const nonTestRepos = [
+      { id: 4, name: "foo" },
+      { id: 5, name: "bar" },
+    ];
 
     simple.mock(octokit, "request").resolveWith(undefined);
 
@@ -313,7 +319,7 @@ withUser("when single repository exists", async () => {
   const owner = "gr2m";
   const repo = "squash-commit-app";
   const octokit = new Octokit({
-    auth: process.env.GITHUB_TOKEN,
+    auth: Deno.env.GITHUB_TOKEN,
   });
 
   const repositories = [`${owner}/${repo}`];
@@ -337,7 +343,7 @@ withUser("when requesting the same repository twice", async () => {
   const owner = "gr2m";
   const repo = "squash-commit-app";
   const octokit = new Octokit({
-    auth: process.env.GITHUB_TOKEN,
+    auth: Deno.env.GITHUB_TOKEN,
   });
 
   const repositories = [`${owner}/${repo}`, `${owner}/${repo}`];
@@ -361,12 +367,15 @@ withUser("when requesting all the repositories", async () => {
   const owner = "octokitbot";
   const repo = "*";
   const octokit = new Octokit({
-    auth: process.env.GITHUB_TOKEN,
+    auth: Deno.env.GITHUB_TOKEN,
   });
 
   const repositories = [`${owner}/${repo}`];
 
-  const mockedResponse = [{ id: 1, name: "repo1" }, { id: 2, name: "repo2" }];
+  const mockedResponse = [
+    { id: 1, name: "repo1" },
+    { id: 2, name: "repo2" },
+  ];
 
   simple.mock(octokit, "request").rejectWith(undefined);
 


### PR DESCRIPTION
## Summary

Migrate from Node to Deno.

## Details

This PR migrates the CLI to leverage Deno. I could run things locally to update `master` -> `main` for a few of my older repositories. The discussion [here](https://github.com/orgs/octoherd/discussions/43) inspired this PR  and works to resolve https://github.com/octoherd/cli/issues/5.

## Testing

- [x] Verified it's working locally with both `.js` and `.ts` files. 
- [x] Ran `scripts/script.js` and `scripts/script.ts` against several of my older repos to update branch protection rules.

```zsh
deno run -A cli.js -T $GITHUB_TOKEN -R '[repo-name]'
```

## Remaining Tasks
- [ ] remove pr sample files (cli.js, script.ts)
- [ ] migrate `package.json` scripts (and more?) to `deno.json`
- [ ] find replacements for `process.arch` and `process.platform`